### PR TITLE
[FEATURE] Custom crop position on ResizeWithCropOrPadOp

### DIFF
--- a/lib/src/image/ops/resize_with_crop_or_pad_op.dart
+++ b/lib/src/image/ops/resize_with_crop_or_pad_op.dart
@@ -118,7 +118,8 @@ class ResizeWithCropOrPadOp implements ImageOperator {
   // This function is used to check the crop custom crop position is valid
   void _checkCropPositionArgument(int w, int h) {
     // Ensure both are null or non-null at the same time else throw argument error.
-    if (_cropLeft != _cropTop) {
+    if ((_cropLeft == null && _cropTop != null) ||
+        (_cropLeft != null && _cropTop == null)) {
       throw ArgumentError(
           "Crop position argument (_cropLeft, _cropTop) is invalid, got: ($_cropLeft, $_cropTop)");
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -233,6 +233,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.5.0"
+  tuple:
+    dependency: "direct main"
+    description:
+      name: tuple
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   path_provider: ^1.6.11
   tflite_flutter: ^0.5.0
   image: ^2.1.4
+  tuple: ^1.0.3
 
 dev_dependencies:
   flutter_test:

--- a/test/tfliteflutterhelper_test.dart
+++ b/test/tfliteflutterhelper_test.dart
@@ -16,6 +16,7 @@ import 'package:tflite_flutter_helper/src/image/tensor_image.dart';
 import 'package:tflite_flutter_helper/src/tensorbuffer/tensorbuffer.dart';
 import 'package:tflite_flutter_helper/src/tensorbuffer/tensorbufferfloat.dart';
 import 'package:tflite_flutter_helper/src/tensorbuffer/tensorbufferuint8.dart';
+import 'package:tuple/tuple.dart';
 
 const int h = 100;
 const int w = 150;
@@ -228,6 +229,25 @@ void main() {
 
         expect(processedImage.height, h);
         expect(processedImage.width, w);
+      });
+
+      test('resize with custom crop position', () {
+        ImageProcessor imageProcessor = ImageProcessorBuilder()
+            .add(ResizeWithCropOrPadOp(h, w, Tuple2<int, int>(0, 0)))
+            .build();
+
+        TensorImage processedImage =
+            imageProcessor.process(TensorImage.fromImage(image));
+
+        expect(processedImage.height, h);
+        expect(processedImage.width, w);
+        // check that the crop position is taken in account
+        // ie:(checking pixel value of the original image vs pixel in crop)
+        for (var i = 0; i < w; i++) {
+          for (var j = 0; j < h; j++) {
+            expect(image.getPixel(i, j), processedImage.image.getPixel(i, j));
+          }
+        }
       });
 
       test('resize with pad', () {

--- a/test/tfliteflutterhelper_test.dart
+++ b/test/tfliteflutterhelper_test.dart
@@ -16,7 +16,6 @@ import 'package:tflite_flutter_helper/src/image/tensor_image.dart';
 import 'package:tflite_flutter_helper/src/tensorbuffer/tensorbuffer.dart';
 import 'package:tflite_flutter_helper/src/tensorbuffer/tensorbufferfloat.dart';
 import 'package:tflite_flutter_helper/src/tensorbuffer/tensorbufferuint8.dart';
-import 'package:tuple/tuple.dart';
 
 const int h = 100;
 const int w = 150;
@@ -233,7 +232,7 @@ void main() {
 
       test('resize with custom crop position', () {
         ImageProcessor imageProcessor = ImageProcessorBuilder()
-            .add(ResizeWithCropOrPadOp(h, w, Tuple2<int, int>(0, 0)))
+            .add(ResizeWithCropOrPadOp(h, w, 0, 0))
             .build();
 
         TensorImage processedImage =
@@ -253,8 +252,18 @@ void main() {
       test('resize with custom crop position outside image', () {
         ImageProcessor imageProcessor = ImageProcessorBuilder()
             // the be sure we are outside we took the input size of the image and add 1 pixel
-            .add(ResizeWithCropOrPadOp(
-                h, w, Tuple2<int, int>(inputWidth + 1, inputHeight + 1)))
+            .add(ResizeWithCropOrPadOp(h, w, inputWidth + 1, inputHeight + 1))
+            .build();
+
+        TensorImage sourceImage = TensorImage.fromImage(image);
+        expect(() => imageProcessor.process(sourceImage),
+            throwsA(isA<ArgumentError>()));
+      });
+
+      test('resize with custom crop and one null argument', () {
+        ImageProcessor imageProcessor = ImageProcessorBuilder()
+            // the be sure we are outside we took the input size of the image and add 1 pixel
+            .add(ResizeWithCropOrPadOp(h, w, 0, null))
             .build();
 
         TensorImage sourceImage = TensorImage.fromImage(image);
@@ -268,10 +277,7 @@ void main() {
         ImageProcessor imageProcessor = ImageProcessorBuilder()
             // the be sure that a part of the crop is outside the iamge we took the input size and substract crop size / 2
             .add(ResizeWithCropOrPadOp(
-                h,
-                w,
-                Tuple2<int, int>(
-                    inputWidth - (w ~/ 2), inputHeight - (h ~/ 2))))
+                h, w, inputWidth - (w ~/ 2), inputHeight - (h ~/ 2)))
             .build();
 
         TensorImage sourceImage = TensorImage.fromImage(image);
@@ -282,7 +288,7 @@ void main() {
       test('resize with a negative a crop position', () {
         ImageProcessor imageProcessor = ImageProcessorBuilder()
             // the be sure that a part of the crop is outside the iamge we took the input size and substract crop size / 2
-            .add(ResizeWithCropOrPadOp(h, w, Tuple2<int, int>(-100, -10)))
+            .add(ResizeWithCropOrPadOp(h, w, -100, -10))
             .build();
 
         TensorImage sourceImage = TensorImage.fromImage(image);


### PR DESCRIPTION
Following the discussion at https://github.com/am15h/tflite_flutter_helper/issues/14, here is a proposed implementation on how to specify a custom crop position for ResizeWithCropOrPadOp.

Tupple have been introduced to specify the crop position to have only one coherent argument. This is open to discussion : two distincts arguments seem to be a valid approach too. 

I just figured out you target the https://github.com/tensorflow/tflite-support API. Thus a PR may be proposed to implement the same feature into https://github.com/tensorflow/tflite-support/blob/master/tensorflow_lite_support/java/src/java/org/tensorflow/lite/support/image/ops/ResizeWithCropOrPadOp.java 

Unit test have been added to cover the new code. 

Please let me know what you think about this.
Have a good day!