### PR TITLE
fixed problem about cropped height

### DIFF
--- a/lib/src/image/ops/resize_with_crop_or_pad_op.dart
+++ b/lib/src/image/ops/resize_with_crop_or_pad_op.dart
@@ -80,7 +80,7 @@ class ResizeWithCropOrPadOp implements ImageOperator {
       // custom crop position. First item of the tuple represent the desired position for top position
       // and the second item the bottom position
       Tuple2<int, int> cropPos =
-          _computeCropPosition(_targetHeight, w, cropHeightCustomPosition);
+          _computeCropPosition(_targetHeight, h, cropHeightCustomPosition);
       srcT = cropPos.item1;
       srcB = cropPos.item2;
     }


### PR DESCRIPTION
When I use object_detection app (https://github.com/am15h/object_detection_flutter) with the master branch of tflite_flutter_helper, range errors happen.
Maybe there is a bug in calculating the cropped height. After this fix, the app works without errors.